### PR TITLE
sinatra / tilt の上限固定を外す (1.3.46)

### DIFF
--- a/config/lib.yaml
+++ b/config/lib.yaml
@@ -6,6 +6,6 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/ginseng-web
-  version: 1.3.45
+  version: 1.3.46
 puma:
   port: 3014

--- a/ginseng-web.gemspec
+++ b/ginseng-web.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack-session', '>=2.1.1' # CVE-2025-46336
   spec.add_dependency 'rss'
   spec.add_dependency 'sassc'
-  spec.add_dependency 'sinatra', '~>4.1.0' # CVE-2024-21510
+  spec.add_dependency 'sinatra', '>=4.1.0' # CVE-2024-21510
   spec.add_dependency 'slim'
-  spec.add_dependency 'tilt', '~>2.1.0'
+  spec.add_dependency 'tilt', '>=2.1.0'
 end


### PR DESCRIPTION
pooza/mulukhiya-toot-proxy#4508 の前提作業。

## 背景

モロヘイヤ側の `Gemfile` に sinatra / tilt の直接指定は無く、**pin は本 gem の gemspec** にある。そのため sinatra 4.2 系へ上げるにはここを先に緩める必要がある。

## 変更

```diff
-spec.add_dependency 'sinatra', '~>4.1.0' # CVE-2024-21510
-spec.add_dependency 'tilt', '~>2.1.0'
+spec.add_dependency 'sinatra', '>=4.1.0' # CVE-2024-21510
+spec.add_dependency 'tilt', '>=2.1.0'
```

rack で先にやった `~>3.1.14` → `>=3.1.14`（0b0370f）と同じ形。**CVE-2024-21510 対策として入れた下限 4.1.0 は保つ**（`host_authorization` 設定が入ったバージョン）。

## 解決結果

| gem | 変更前 | 変更後 |
| --- | --- | --- |
| sinatra | 4.1.1 | **4.2.1** |
| rack-protection | 4.1.1 | **4.2.1** |
| tilt | 2.1.0 | **2.8.0** |
| mustermann | 3.1.1 | 3.1.1（据え置き） |

⚠ **mustermann 4.0.0 は入らない。**sinatra 4.2.1 が `mustermann (~> 3.0)` を要求するため。#4508 の起票時は「mustermann のメジャー更新」を含む前提だったが、実際には sinatra 側が上げるまで来ない。

## CHANGELOG 確認

- **sinatra 4.2.0/4.2.1**: `:static_headers` 設定の追加、`etag_matches?` の ReDoS 修正、malformed Content-Type の修正。4.2.0 で入った「`PATH_INFO` can never be empty」は 4.2.1 で revert 済み。破壊的変更なし
- **tilt 2.2.0〜2.8.0**: 削除・非推奨はいずれも未使用のテンプレートエンジン（creole / erubis / wikicloth / maruku / BlueCloth / Less / Sigil / RedCarpet 1.x / CoffeeScript / Prawn）と `Tilt.current_template` / `Tilt::Cache`。本 gem は slim / erb / sassc のみで、`Tilt` を直接参照するコードも無い

## 検証

- `bundle exec rake test`: 35 tests, 50 assertions, 0 failures, 0 errors
- `bundle exec rubocop`: 32 files, no offenses

⚠ 本 gem は #4053 で `Ginseng::Web::Sinatra` を削除済みなので、**Sinatra を実際に使うのはモロヘイヤ側の `Controller < Sinatra::Base` だけ**。実質の検証はモロヘイヤ側の harness 実走で行う。